### PR TITLE
Update Inst-WebTools.sh

### DIFF
--- a/QNAP/shared/Inst-WebTools.sh
+++ b/QNAP/shared/Inst-WebTools.sh
@@ -60,7 +60,7 @@ case "$1" in
 	/sbin/log_tool -t 0 -a "Starting $QPKG_NAME from $DIR"
 	downloadWT
 	extractWT
-	@/sbin/setcfg PlexInst Enable FALSE -f /etc/config/qpkg.conf
+	/sbin/setcfg PlexInst Enable FALSE -f /etc/config/qpkg.conf
     ;;
 
   stop)


### PR DESCRIPTION
on my qnap TS-669L with Firmware 4.2.1 I had to remove the "@" in line 63 to get it to work. Not sure what the @ is supposed to do there, couldn't find anything in shell script documentation

[/share/CACHEDEV1_DATA/.qpkg/Inst-WebTools] # ./Inst-WebTools.sh start
./Inst-WebTools.sh: line 63: @/sbin/setcfg: No such file or directory
